### PR TITLE
[Feature] 테스트 환경 배포를 위한 Github action 워크플로우 작성

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Python Lambda to AWS (from src)
+
+on:
+  push:
+    branches:
+      - test-deploy
+
+jobs:
+  deploy_lambda:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt -t ./src
+          
+      - name: Zip deployment package
+        run: |
+          cd src
+          zip -r ../deployment-package.zip .
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Deploy to AWS Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name analyzeTermOfServicesTest \
+            --zip-file fileb://deployment-package.zip


### PR DESCRIPTION
# 관련 이슈
- closes #10 

# 작업사항
- 로컬에서 bedrock을 호출하는 등의 기능이 사용이 불가능한 관계로, 실제 배포 환경에서 테스트가 가능하도록 테스트용 Lambda 함수를 제작하고, test-deploy 브랜치에 병합되는 내용을 해당 Lambda 함수에 자동으로 배포하도록 했습니다.

# 기타
