### PR TITLE
claude의 응답을 여는 중괄호부터 닫는 중괄호까지 잘라 사용

### DIFF
--- a/src/tos_evaluate.py
+++ b/src/tos_evaluate.py
@@ -62,5 +62,10 @@ JSON 형식 이외에 서론이나 결론, 코드 블럭 따위는 절대로 포
     print("TOS Evaluation Response:")
     print(response)
 
+    text = response['output']['message']['content'][0]['text']
+    start = text.find('{')
+    end = text.rfind('}') + 1
+    json_text = text[start:end]
+
     # response에서 JSON 파싱 후 반환
-    return json.loads(response['output']['message']['content'][0]['text'])
+    return json.loads(json_text)


### PR DESCRIPTION
# 관련 이슈
- #9 

# 작업사항
- Claude 모델의 응답이 명시한 양식임을 신뢰할 수 없으므로, 응답에 포함된 처음 여는 중괄호부터 마지막 닫는 중괄호까지 잘라내 사용합니다.

# 기타
