### PR TITLE
마크다운으로 변환된 내용 대신 원본과 변환된 길이 및 감소율을 출력하도록 변경

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -29,8 +29,14 @@ def lambda_handler(event, context):
     url = event['queryStringParameters']['url']
     tos_content = md(event['body'])
 
-    print('markdownified TOS content:')
-    print(tos_content)
+    # 바이트 기준으로 길이 및 감소율 계산
+    original_length = len(event['body'].encode('utf-8'))
+    markdown_length = len(tos_content.encode('utf-8'))
+    reduction = (original_length - markdown_length) / original_length * 100
+    
+    print(f"원본 html 길이: {original_length} bytes")
+    print(f"markdown 길이: {markdown_length} bytes")
+    print(f"감소율: {reduction:.4f}%")
 
     # TODO: 기존 URL 기반 캐싱 로직 구현
 


### PR DESCRIPTION
# 관련 이슈
- #20 

# 작업사항
- 기존에 마크다운으로 파싱된 전체 텍스트를 출력하던 코드를 원본 html과 마크다운으로 변환된 길이 및 감소율을 출력하도록 변경했습니다. 이전 코드는 CloudWatch에서 지나치게 보기 힘들고 html과 내용상의 차이는 없어 이런 방식을 적용합니다.

# 기타
현재는 바이트 수를 기준으로 하며, 추후 토큰 기반으로 조금 더 실제 사용량 및 비용에 비례하도록 변경할 수 있습니다.