### PR TITLE
fix: text_splitter의 마지막 쓸데없는 2문장 제거

### DIFF
--- a/src/text_splitter.py
+++ b/src/text_splitter.py
@@ -32,7 +32,3 @@ def split_sentences_block(block: str, client: LLMClient) -> List[str]:
 
     sentences = _extract_json_array(response)
     return [str(s).strip() for s in sentences if str(s).strip()]
-
-
-sentences = split_sentences_block(tos_content, client)
-print(f"문장 분할 개수: {len(sentences)}")


### PR DESCRIPTION
#30

# 관련 이슈
- #30 

# 작업사항
- text_splitter 에러제거
